### PR TITLE
bug fixed

### DIFF
--- a/toolkits/wenet/gigaspeech_data_prep.sh
+++ b/toolkits/wenet/gigaspeech_data_prep.sh
@@ -100,7 +100,7 @@ if [ $stage -le 1 ]; then
   # Files to be created:
   # wav.scp text segments utt2dur
   python3 toolkits/wenet/extract_meta.py \
-     $gigaspeech_dir/GigaSpeech.json $corpus_dir | exit 1;
+     $gigaspeech_dir/GigaSpeech.json $corpus_dir || exit 1;
 fi
 
 if [ $stage -le 2 ]; then


### PR DESCRIPTION
‘|’ is Pipe symbol，not ‘or’ operation,it may  cause a BrokenPipeError。
![image](https://user-images.githubusercontent.com/25433706/172327115-1d106922-4e4a-41b0-af74-1f20dcac3c35.png)
