### PR TITLE
Add utt2spk_to_spk2utt.pl to repo and fix path

### DIFF
--- a/toolkits/kaldi/gigaspeech_data_prep.sh
+++ b/toolkits/kaldi/gigaspeech_data_prep.sh
@@ -109,7 +109,7 @@ if [ $stage -le 1 ]; then
     --pipe-format $gigaspeech_dir/GigaSpeech.json $corpus_dir || exit 1;
   utt2spk=$corpus_dir/utt2spk
   spk2utt=$corpus_dir/spk2utt
-  utt2spk_to_spk2utt.pl <$utt2spk >$spk2utt ||\
+  toolkits/kaldi/utt2spk_to_spk2utt.pl <$utt2spk >$spk2utt ||\
     (echo "$0: utt2spk to spk2utt" && exit 1) || exit 1;
 fi
 

--- a/toolkits/kaldi/utt2spk_to_spk2utt.pl
+++ b/toolkits/kaldi/utt2spk_to_spk2utt.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+# Copyright 2010-2011 Microsoft Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+# converts an utt2spk file to a spk2utt file.
+# Takes input from the stdin or from a file argument;
+# output goes to the standard out.
+
+if ( @ARGV > 1 ) {
+    die "Usage: utt2spk_to_spk2utt.pl [ utt2spk ] > spk2utt";
+}
+
+while(<>){ 
+    @A = split(" ", $_);
+    @A == 2 || die "Invalid line in utt2spk file: $_";
+    ($u,$s) = @A;
+    if(!$seen_spk{$s}) {
+        $seen_spk{$s} = 1;
+        push @spklist, $s;
+    }
+    push (@{$spk_hash{$s}}, "$u");
+}
+foreach $s (@spklist) {
+    $l = join(' ',@{$spk_hash{$s}});
+    print "$s $l\n";
+}
+


### PR DESCRIPTION
for issue https://github.com/SpeechColab/GigaSpeech/issues/121
Before:
```
np@np-INTEL:/mnt/speech1/nadira/GigaSpeech$ toolkits/kaldi/gigaspeech_data_prep.sh --train-subset XL /mnt/speech2/gigaspeech ../data
toolkits/kaldi/gigaspeech_data_prep.sh: Extract meta into ../data/gigaspeech_corpus/
toolkits/kaldi/gigaspeech_data_prep.sh: line 112: utt2spk_to_spk2utt.pl: command not found
toolkits/kaldi/gigaspeech_data_prep.sh: utt2spk to spk2utt
```

After:
```
np@np-INTEL:/mnt/speech1/nadira/GigaSpeech$ toolkits/kaldi/gigaspeech_data_prep.sh --train-subset XL /mnt/speech2/gigaspeech ../data
toolkits/kaldi/gigaspeech_data_prep.sh: Extract meta into ../data/gigaspeech_corpus/
toolkits/kaldi/gigaspeech_data_prep.sh: Filter ../data/gigaspeech_corpus//text
toolkits/kaldi/gigaspeech_data_prep.sh: Split data to train, dev and test
toolkits/kaldi/gigaspeech_data_prep.sh: Done
np@np-INTEL:/mnt/speech1/nadira/GigaSpeech$ 
```
After changes, script created Kaldi style folder that looks correct but I didn't use it yet.  